### PR TITLE
fix: public algorithms details not shown

### DIFF
--- a/WebCLI/views.py
+++ b/WebCLI/views.py
@@ -50,7 +50,7 @@ def new_algorithm(request):
 
 def algorithm_details_view(request):
     algorithm = Algorithm.objects.get(pk=request.GET.get("index"))
-    if request.user.pk != algorithm.user.pk:
+    if not algorithm.public and request.user.pk != algorithm.user.pk:
         raise PermissionDenied
 
     return render(request, 'WebCLI/algorithm.html', {'algorithm': algorithm})


### PR DESCRIPTION
## Description

Last pr I added safeguard that private algorithms can not be viewed by others. It raised problem that even public algorithms can not be viewed by others users. This is small fix for that.

## How to test

One can see all public algorithms, users own private ones, but not other users private ones. Not even by manipulating http address.
