### PR TITLE
Fix: Actions to update the docker image once per workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -35,19 +35,19 @@ jobs:
       # run: |
         # pytest
     - name: Set up QEMU
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && matrix.python-version == '3.9' }}
       uses: docker/setup-qemu-action@v1
     - name: Set up Docker Buildx
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && matrix.python-version == '3.9' }}
       uses: docker/setup-buildx-action@v1
     - name: Login to DockerHub
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && matrix.python-version == '3.9' }}
       uses: docker/login-action@v1
       with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
     - name: Build and push
-      if: ${{ github.event_name == 'push' }}
+      if: ${{ github.event_name == 'push' && matrix.python-version == '3.9' }}
       uses: docker/build-push-action@v2
       with:
         push: true


### PR DESCRIPTION
Currently Github Actions tries to upload a new Docker image three times per workflow. This PR aims to fix that.