### PR TITLE
added restrictions to negative metrics & only numeric

### DIFF
--- a/WebCLI/tests.py
+++ b/WebCLI/tests.py
@@ -386,6 +386,50 @@ class WebFunctionTestViewData(TestCase):
         self.assertEqual(v2.circuit_depth, None)
         self.assertEqual(v2.accuracy, None)
 
+    def test_add_negative_iteration_metrics(self):
+        a = Algorithm.objects.get(name='Algo3')
+        v = Algorithm_version.objects.filter(algorithm_id=a)[0]
+        response = self.client.post('/addMetrics/?index=' + str(v.pk),
+                                    {'iterations': '-1',
+                                     'measurements': '1',
+                                     'circuit_depth': '2',
+                                     'accuracy': '3.1'})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(str(response.content).find('Input value must be positive') < 0)
+
+    def test_add_nonumeric_iteration_metrics(self):
+        a = Algorithm.objects.get(name='Algo3')
+        v = Algorithm_version.objects.filter(algorithm_id=a)[0]
+        response = self.client.post('/addMetrics/?index=' + str(v.pk),
+                                    {'iterations': 'aa',
+                                     'measurements': '1',
+                                     'circuit_depth': '2',
+                                     'accuracy': '3.1'})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(str(response.content).find('Metrics input needs to be numeric') < 0)
+
+    def test_add_negative_accuracy_metrics(self):
+        a = Algorithm.objects.get(name='Algo3')
+        v = Algorithm_version.objects.filter(algorithm_id=a)[0]
+        response = self.client.post('/addMetrics/?index=' + str(v.pk),
+                                    {'iterations': '7',
+                                     'measurements': '1',
+                                     'circuit_depth': '2',
+                                     'accuracy': '-3.1'})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(str(response.content).find('Input value must be positive') < 0)
+
+    def test_add_nonumeric_accuracy_metrics(self):
+        a = Algorithm.objects.get(name='Algo3')
+        v = Algorithm_version.objects.filter(algorithm_id=a)[0]
+        response = self.client.post('/addMetrics/?index=' + str(v.pk),
+                                    {'iterations': '7',
+                                     'measurements': '1',
+                                     'circuit_depth': '2',
+                                     'accuracy': 'aa'})
+        self.assertEqual(response.status_code, 400)
+        self.assertFalse(str(response.content).find('Metrics input needs to be numeric') < 0)
+
     def test_add_metrics_view(self):
         a = Algorithm.objects.get(name='Algo3')
         v = Algorithm_version.objects.filter(algorithm_id=a)[0]

--- a/WebCLI/views.py
+++ b/WebCLI/views.py
@@ -6,7 +6,7 @@ from django.core.exceptions import PermissionDenied
 from django.urls import reverse_lazy
 from django.utils.html import format_html
 from django.views import generic
-from django.forms import ModelForm, Textarea, HiddenInput, IntegerField, FloatField, Form, CharField
+from django.forms import ModelForm, Textarea, HiddenInput, IntegerField, FloatField, Form, CharField, ValidationError
 from django_tables2.columns.base import Column
 from django_tables2.columns import TemplateColumn
 from .models import Algorithm, Molecule, Algorithm_type, Algorithm_version
@@ -15,6 +15,8 @@ from django.utils.decorators import method_decorator
 from django_filters import AllValuesFilter, FilterSet
 from django_filters.views import FilterView
 from django_tables2 import SingleTableMixin, Table
+from django.core.validators import MinValueValidator
+from django.utils.translation import gettext as _
 
 
 class AlgorithmFilter(FilterSet):
@@ -94,11 +96,10 @@ class AlgorithmVersionForm(Form):
 
 
 class MetricsForm(Form):
-    iterations = IntegerField(required=False)
-    measurements = IntegerField(required=False)
-    circuit_depth = IntegerField(required=False)
-    accuracy = FloatField(required=False)
-
+    iterations = IntegerField(required=False, min_value=0)
+    measurements = IntegerField(required=False, min_value=0)
+    circuit_depth = IntegerField(required=False, min_value=0)
+    accuracy = FloatField(required=False, min_value=0.0)
 
 @login_required
 def new_algorithm(request):
@@ -180,18 +181,46 @@ def add_metrics(request):
         form = MetricsForm(request.POST).data
         if form['iterations']:
             av.iterations = form['iterations']
+            if not av.iterations.isnumeric():
+                raise ValidationError(
+                    _('Metrics input needs to be numeric; "%(value)s" was not numeric'),
+                    params={'value': av.iterations},
+                )
+            elif int(av.iterations) < 0:
+                raise ValidationError('Input value must be positive')
         else:
             av.iterations = None
         if form['measurements']:
             av.measurements = form['measurements']
+            if not av.measurements.isnumeric():
+                raise ValidationError(
+                    _('Metrics input needs to be numeric; "%(value)s" was not numeric'),
+                    params={'value': av.measurements},
+                )
+            elif int(av.measurements) < 0:
+                raise ValidationError('Input value must be positive')
         else:
             av.measurements = None
         if form['circuit_depth']:
             av.circuit_depth = form['circuit_depth']
+            if not av.circuit_depth.isnumeric():
+                raise ValidationError(
+                    _('Metrics input needs to be numeric; "%(value)s" was not numeric'),
+                    params={'value': av.circuit_depth},
+                )
+            elif int(av.circuit_depth) < 0:
+                raise ValidationError('Input value must be positive')
         else:
             av.circuit_depth = None
         if form['accuracy']:
             av.accuracy = form['accuracy']
+            if not av.accuracy.isnumeric():
+                raise ValidationError(
+                    _('Metrics input needs to be numeric; "%(value)s" was not numeric'),
+                    params={'value': av.accuracy},
+                )
+            elif int(av.accuracy) < 0:
+                raise ValidationError('Input value must be positive')
         else:
             av.accuracy = None
         av.save()


### PR DESCRIPTION
## Summary
Edited `view.py` forms and add_metric function so that it non-negative metrics cannot be added and only numeric metrics can be added. This PR closes #57.
## How to test
Try to add metrics with negative values. Try to edit html within browser so that you can post strings instead of numbers. Both should throw a ValidationError.