### PR TITLE
Removing Heroku

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -39,8 +39,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: psycopb2 prequisites
-      run: sudo apt-get install python-dev libpq-dev
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -61,7 +61,6 @@ jobs:
       run: curlylint templates/
     - name: Test with Django
       run: |
-        python manage.py collectstatic
         coverage erase
         coverage run manage.py test
     - name: "Upload coverage to Codecov"

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-release: python manage.py makemigrations && python manage.py migrate
-web: gunicorn WebMark.wsgi 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ WebMark = Project
 
 WebCLI = Application
 
-Requirements: django, django-on-heroku, gunicorn, django-dotenv, flake8, flake8-django
+Requirements: see [requirements.txt](requirements.txt)
 
 ## Database schema
 
@@ -106,11 +106,6 @@ Run tests
 python manage.py test
 ```
 
-If missing staticfiles error appears:
-```
-python manage.py collectstatic
-```
-
 Run code coverage
 ```
 coverage erase
@@ -124,10 +119,3 @@ python manage.py makemigrations
 python manage.py migrate
 
 ```
-
-You can push your local PostgreSQL database to Heroku with
-```
-heroku pg:push postgres://quantuser@localhost/quantdb  postgresql-flexible-07270 --app=quantmark
-```
-
-

--- a/WebMark/settings.py
+++ b/WebMark/settings.py
@@ -12,7 +12,6 @@ https://docs.djangoproject.com/en/3.1/ref/settings/
 
 from pathlib import Path
 
-import django_on_heroku
 import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -139,8 +138,3 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = [
     BASE_DIR / "static",
 ]
-
-
-# Configure Django App for Heroku.
-
-django_on_heroku.settings(locals())


### PR DESCRIPTION
## Summary
Removing Heroku support as it is not used. This also fixes the issues with tests not passing without running `python manage.py collectstatic` first.
## How to test
Check that tests pass with an empty staticfiles folder. Also check that the server starts correctly.