### PR TITLE
Update django 316

### DIFF
--- a/WebMark/settings.py
+++ b/WebMark/settings.py
@@ -27,7 +27,7 @@ SECRET_KEY = '(enfmztw6!r!b7^_s31p68cqm-)w8g(qru+od0bc9oz&6_0q!9'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['0.0.0.0']
 
 
 # Application definition

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ beautifulsoup4==4.9.3
 click==7.1.2
 curlylint==0.12.2
 dj-database-url==0.5.0
-Django==3.1.5
+Django==3.1.6
 django-bootstrap4==2.3.1
 django-dotenv==1.4.2
 django-filter==2.4.0


### PR DESCRIPTION
## Summary
User story: #85 

Django version updated to 3.1.6. Seems to work ok. Except that when using docker I got message "Invalid HTTP_HOST header: '0.0.0.0:8000'. You may need to add '0.0.0.0' to ALLOWED_HOSTS.". I added 0.0.0.0 allowed hosts in settings.py. Works ok after that. ok solution?

## How to test
Test that everything works ok. 