### PR TITLE
Some fixes for staging

### DIFF
--- a/WebCLI/views/test_algorithm.py
+++ b/WebCLI/views/test_algorithm.py
@@ -26,4 +26,4 @@ def test_algorithm(request):
         metrics_id, model_to_dict(molecule), version.circuit,
         version.optimizer_module, version.optimizer_method
     )
-    return redirect('/myAlgorithms/')
+    return redirect('myAlgorithms')

--- a/WebMark/settings.py
+++ b/WebMark/settings.py
@@ -28,7 +28,7 @@ SECRET_KEY = '(enfmztw6!r!b7^_s31p68cqm-)w8g(qru+od0bc9oz&6_0q!9'
 DEBUG = True
 
 ALLOWED_HOSTS = [
-    'ohtup-staging.cs.helsinki.fi', '0.0.0.0', '127.0.0.1', 'localhost', 'web', 'quantmark_web'
+    'ohtup-staging.cs.helsinki.fi', '0.0.0.0', '127.0.0.1', 'localhost', 'web', 'quantmark-web'
 ]
 
 # Application definition

--- a/docker-compose-staging.yml
+++ b/docker-compose-staging.yml
@@ -1,35 +1,50 @@
 # copy of the docker-compose.yml that exists on the staging server
 version: "3.7"
-   
+
 services:
-  quantmark_db:
+  quantmark-db:
     image: postgres:13.1
     environment:
       - POSTGRES_DB=postgres
       - POSTGRES_USER=postgres
       - POSTGRES_PASSWORD=postgres
-    container_name: quantmark_db
+    container_name: quantmark-db
     restart: unless-stopped
 
-  quantmark_web:
+  quantmark-rabbitmq:
+    image: rabbitmq:3.8
+    container_name: quantmark-rabbitmq
+    restart: unless-stopped
+
+  quantmark-web:
     image: tapanih/quantmark_web
     environment:
       - DATABASE_NAME=postgres
       - DATABASE_USER=postgres
       - DATABASE_PASSWORD=postgres
-      - DATABASE_HOST=quantmark_db
+      - DATABASE_HOST=quantmark-db
       - DATABASE_PORT=5432
       - ROOT_DIR=quantmark/
+      - BROKER_URL=pyamqp://guest@quantmark-rabbitmq//
     command: sh -c "
-      python manage.py makemigrations WebCLI && 
-      python manage.py migrate && 
+      python manage.py makemigrations WebCLI &&
+      python manage.py migrate &&
       gunicorn WebMark.wsgi -b 0.0.0.0:8000"
-    container_name: quantmark_web
+    container_name: quantmark-web
     restart: unless-stopped
     depends_on:
-      - quantmark_db
+      - quantmark-db
+
+  quantmark-benchmark:
+    image: tapanih/quantmark_benchmark
+    environment:
+    - BROKER_URL=pyamqp://guest@quantmark-rabbitmq//
+    - DJANGO_API_URL=http://quantmark-web:8000/quantmark/handleResult
+    command: conda run --no-capture-output -n benchmark celery -A benchmark worker -l info
+    container_name: quantmark-benchmark
+    restart: unless-stopped
 
 networks:
   default:
-    external: 
+    external:
       name: ohtup


### PR DESCRIPTION
## Summary
Added the current docker-compose.yml file that exists on the staging server. Also changed service names to not have underscores because those are invalid in host names and application server does not like it. This means that a small fix in ALLOWED_HOSTS is needed. Redirect after submitting a benchmark task was also broken because it used a hard-coded path instead of view name. Please try to use view names in the future!
## How to test
Test that redirect works

