### PR TITLE
Fixed redirects to login page in staging

### DIFF
--- a/WebMark/settings.py
+++ b/WebMark/settings.py
@@ -122,6 +122,10 @@ USE_L10N = True
 
 USE_TZ = True
 
+# Redirects
+
+LOGIN_URL = 'login'
+
 LOGIN_REDIRECT_URL = 'home'
 
 LOGOUT_REDIRECT_URL = 'home'


### PR DESCRIPTION
## Summary
The redirect to login page did not work because login_required decorator uses a hard coded url to /accounts/login by default. Fixed by switching to using view name. Fixes #121 
## How to test
Check that redirects to login page work normally