### PR TITLE
Average history & Accuracy history results

### DIFF
--- a/WebCLI/tests/testViewingData.py
+++ b/WebCLI/tests/testViewingData.py
@@ -1,8 +1,10 @@
 from django.test import TestCase
+from unittest import mock
 from django.contrib.auth.models import User
-from ..models import Molecule, Algorithm_type, Algorithm, Algorithm_version, Metrics
+from ..models import Molecule, Algorithm_type, Average_history, Algorithm, Algorithm_version, Metrics
 from django.urls import reverse
 from django.utils import timezone
+from ..views.worker_api import as_average_history
 import datetime
 import pytz
 
@@ -229,3 +231,9 @@ class TestViewData(TestCase):
         a = Algorithm.objects.get(name='Algo4')
         response = self.client.get('/updateAlgorithm/?index='+str(a.pk))
         self.assertEqual(response.status_code, 403)
+
+    def test_get_benchmark_results_average_history(self):
+        mock_libmark = mock.Mock()
+        result = {'average_history': [0.23, 0.34, 0.45, 0.56], 'metrics_id': 1 }
+        as_average_history(result)
+        self.assertEqual(Average_history.objects.all(), 4)

--- a/WebCLI/views/test_algorithm.py
+++ b/WebCLI/views/test_algorithm.py
@@ -22,7 +22,7 @@ def test_algorithm(request):
         metrics.save()
         metrics_id = metrics.pk
         average_history = Average_history(
-            analyzed_results=metrics_id,
+            analyzed_results=metrics,
             data=None,
             iteration_number=None)
         average_history.save()

--- a/WebCLI/views/test_algorithm.py
+++ b/WebCLI/views/test_algorithm.py
@@ -25,7 +25,8 @@ def test_algorithm(request):
             analyzed_results=metrics_id,
             data=None,
             iteration_number=None)
-        )
+        average_history.save()
+
 
     send_benchmark_task(
         metrics_id, model_to_dict(molecule), version.circuit,

--- a/WebCLI/views/test_algorithm.py
+++ b/WebCLI/views/test_algorithm.py
@@ -2,7 +2,7 @@ from django.shortcuts import redirect
 from ..models import Molecule, Algorithm_version
 from WebCLI.celery.task_sender import send_benchmark_task
 from django.forms.models import model_to_dict
-from WebCLI.models import Metrics
+from WebCLI.models import Metrics, Average_history
 
 
 def test_algorithm(request):
@@ -21,6 +21,11 @@ def test_algorithm(request):
             success_rate=None)
         metrics.save()
         metrics_id = metrics.pk
+        average_history = Average_history(
+            analyzed_results=metrics_id,
+            data=None,
+            iteration_number=None)
+        )
 
     send_benchmark_task(
         metrics_id, model_to_dict(molecule), version.circuit,

--- a/WebCLI/views/test_algorithm.py
+++ b/WebCLI/views/test_algorithm.py
@@ -21,12 +21,6 @@ def test_algorithm(request):
             success_rate=None)
         metrics.save()
         metrics_id = metrics.pk
-        average_history = Average_history(
-            analyzed_results=metrics_id,
-            data=None,
-            iteration_number=None)
-        average_history.save()
-
 
     send_benchmark_task(
         metrics_id, model_to_dict(molecule), version.circuit,

--- a/WebCLI/views/test_algorithm.py
+++ b/WebCLI/views/test_algorithm.py
@@ -2,7 +2,7 @@ from django.shortcuts import redirect
 from ..models import Molecule, Algorithm_version
 from WebCLI.celery.task_sender import send_benchmark_task
 from django.forms.models import model_to_dict
-from WebCLI.models import Metrics, Average_history
+from WebCLI.models import Metrics
 
 
 def test_algorithm(request):

--- a/WebCLI/views/worker_api.py
+++ b/WebCLI/views/worker_api.py
@@ -18,7 +18,7 @@ def as_average_history(result):
     average_history = Average_history.objects.get(fk=result["metrics_id"])
     print("tÄLLÄISTÄ " + result["average_history"])
     average_history.data = result["average_history"]
-    return metrics
+    return average_history
 
 # TODO: set this route to accept from workers only
 @csrf_exempt

--- a/WebCLI/views/worker_api.py
+++ b/WebCLI/views/worker_api.py
@@ -15,14 +15,17 @@ def as_analyzed_results(result):
     return metrics
 
 def as_average_history(result):
-    average_history = Average_history.objects.get(fk=result["metrics_id"])
+    # tässä joku ongelma
+    average_history = Average_history.objects.get(pk= result["metrics_id"])
     print("tÄLLÄISTÄ " + result["average_history"])
     average_history.data = result["average_history"]
-    return metrics
+    return average_history
 
 # TODO: set this route to accept from workers only
 @csrf_exempt
 def handle_result(request):
     analyzed_results = json.loads(request.POST["data"], object_hook=as_analyzed_results)
     analyzed_results.save()
+    average_history = json.loads(request.POST["data"], object_hook=as_average_history)
+    average_history.save()
     return HttpResponse("ok")

--- a/WebCLI/views/worker_api.py
+++ b/WebCLI/views/worker_api.py
@@ -14,6 +14,7 @@ def as_analyzed_results(result):
     metrics.success_rate = result["success_rate"]
     return metrics
 
+
 def as_average_history(result):
     histories = result["average_history"]
     for i in range(len(histories)):
@@ -23,6 +24,7 @@ def as_average_history(result):
             iteration_number=i)
         average_history.save()
     return average_history
+
 
 # TODO: set this route to accept from workers only
 @csrf_exempt

--- a/WebCLI/views/worker_api.py
+++ b/WebCLI/views/worker_api.py
@@ -1,6 +1,6 @@
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
-from ..models import Metrics, Average_history
+from ..models import Metrics, Average_history, Accuracy_history
 from django.utils import timezone
 import json
 
@@ -26,6 +26,17 @@ def as_average_history(result):
     return average_history
 
 
+def as_accuracy_history(result):
+    histories = result["accuracy_history"]
+    for i in range(len(histories)):
+        accuracy_history = Accuracy_history(
+            analyzed_results=Metrics.objects.get(pk=result["metrics_id"]),
+            data=histories[i],
+            iteration_number=i)
+        accuracy_history.save()
+    return accuracy_history
+
+
 # TODO: set this route to accept from workers only
 @csrf_exempt
 def handle_result(request):
@@ -33,4 +44,6 @@ def handle_result(request):
     analyzed_results.save()
     avg_history_results = json.loads(request.POST["data"], object_hook=as_average_history)
     avg_history_results.save()
+    avg_accuracy_results = json.loads(request.POST["data"], object_hook=as_accuracy_history)
+    avg_accuracy_results.save()
     return HttpResponse("ok")

--- a/WebCLI/views/worker_api.py
+++ b/WebCLI/views/worker_api.py
@@ -1,6 +1,6 @@
 from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
-from ..models import Metrics
+from ..models import Metrics, Average_history
 from django.utils import timezone
 import json
 
@@ -14,6 +14,14 @@ def as_analyzed_results(result):
     metrics.success_rate = result["success_rate"]
     return metrics
 
+def as_average_history(result):
+    average_history = Average_history.objects.get(pk=result["metrics_id"])
+    metrics.qubit_count = result["qubit_count"]
+    metrics.timestamp = timezone.now()
+    metrics.gate_depth = result["gate_depth"]
+    metrics.average_iterations = result["average_iterations"]
+    metrics.success_rate = result["success_rate"]
+    return metrics
 
 # TODO: set this route to accept from workers only
 @csrf_exempt

--- a/WebCLI/views/worker_api.py
+++ b/WebCLI/views/worker_api.py
@@ -15,9 +15,13 @@ def as_analyzed_results(result):
     return metrics
 
 def as_average_history(result):
-    average_history = Average_history.objects.get(fk=result["metrics_id"])
-    print("tÄLLÄISTÄ " + result["average_history"])
-    average_history.data = result["average_history"]
+    histories = result["average_history"]
+    for i in range(len(histories)):
+        average_history = Average_history(
+            analyzed_results=Metrics.objects.get(pk=result["metrics_id"]),
+            data=histories[i],
+            iteration_number=i)
+        average_history.save()
     return average_history
 
 # TODO: set this route to accept from workers only
@@ -25,4 +29,6 @@ def as_average_history(result):
 def handle_result(request):
     analyzed_results = json.loads(request.POST["data"], object_hook=as_analyzed_results)
     analyzed_results.save()
+    avg_history_results = json.loads(request.POST["data"], object_hook=as_average_history)
+    avg_history_results.save()
     return HttpResponse("ok")

--- a/WebCLI/views/worker_api.py
+++ b/WebCLI/views/worker_api.py
@@ -15,12 +15,9 @@ def as_analyzed_results(result):
     return metrics
 
 def as_average_history(result):
-    average_history = Average_history.objects.get(pk=result["metrics_id"])
-    metrics.qubit_count = result["qubit_count"]
-    metrics.timestamp = timezone.now()
-    metrics.gate_depth = result["gate_depth"]
-    metrics.average_iterations = result["average_iterations"]
-    metrics.success_rate = result["success_rate"]
+    average_history = Average_history.objects.get(fk=result["metrics_id"])
+    print("tÄLLÄISTÄ " + result["average_history"])
+    average_history.data = result["average_history"]
     return metrics
 
 # TODO: set this route to accept from workers only


### PR DESCRIPTION
## Summary
Average history & Accuracy history results are now saved into the database when benchmarking. This data is not used anywhere yet.
Resolves #113, resolves #114
## How to test
Running the benchmark should now add accuracy history and average history into the database. CI has also some tests on this functionality too.