### PR TITLE
One option for basis set

### DIFF
--- a/WebCLI/forms.py
+++ b/WebCLI/forms.py
@@ -7,6 +7,7 @@ from .models import Algorithm, Molecule, Algorithm_type, Algorithm_version, Metr
 import quantmark as qm
 from .misc.optimizer_methods import get_methods, get_modules
 
+BASIS_SET_CHOICES = ['sto-3g']
 
 class AlgorithmForm(ModelForm):
     class Meta:
@@ -94,7 +95,7 @@ class MoleculeForm(ModelForm):
         }
         widgets = {
             'name': TextInput(),
-            'basis_set': TextInput(),
+            'basis_set': Select(choices=((x, x) for x in BASIS_SET_CHOICES)),
             'transformation': TextInput(),
             'structure': Textarea(attrs={'rows': 6, 'cols': 50}),
             'active_orbitals': Textarea(attrs={'rows': 6, 'cols': 50}),

--- a/WebCLI/forms.py
+++ b/WebCLI/forms.py
@@ -5,9 +5,8 @@ from django.forms import ModelForm, Textarea, HiddenInput, Select, ChoiceField
 from django.forms.widgets import NumberInput, TextInput
 from .models import Algorithm, Molecule, Algorithm_type, Algorithm_version, Metrics
 import quantmark as qm
-from .misc.optimizer_methods import get_methods, get_modules
+from .misc.analyze_options import optimizer_methods, optimizer_modules, basis_set_options
 
-BASIS_SET_CHOICES = ['sto-3g']
 
 class AlgorithmForm(ModelForm):
     class Meta:
@@ -33,7 +32,7 @@ class AlgorithmVersionForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if 'initial' in kwargs:
-            methods = get_methods(kwargs['initial']['optimizer_module'])
+            methods = optimizer_methods(kwargs['initial']['optimizer_module'])
             self.fields['optimizer_method'] = ChoiceField(choices=((x, x) for x in methods))
 
     def clean_circuit(self):
@@ -51,7 +50,7 @@ class AlgorithmVersionForm(ModelForm):
             'algorithm_id': HiddenInput(),
             'algorithm': Textarea(attrs={'rows': 6}),
             'circuit': Textarea(attrs={'rows': 10}),
-            'optimizer_module': Select(choices=((x, x) for x in get_modules()),
+            'optimizer_module': Select(choices=((x, x) for x in optimizer_modules()),
                                        attrs={'class': 'form-control'}),
         }
         labels = {
@@ -95,7 +94,7 @@ class MoleculeForm(ModelForm):
         }
         widgets = {
             'name': TextInput(),
-            'basis_set': Select(choices=((x, x) for x in BASIS_SET_CHOICES)),
+            'basis_set': Select(choices=((x, x) for x in basis_set_options())),
             'transformation': TextInput(),
             'structure': Textarea(attrs={'rows': 6, 'cols': 50}),
             'active_orbitals': Textarea(attrs={'rows': 6, 'cols': 50}),

--- a/WebCLI/forms.py
+++ b/WebCLI/forms.py
@@ -32,8 +32,11 @@ class AlgorithmVersionForm(ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if 'initial' in kwargs:
-            methods = optimizer_methods(kwargs['initial']['optimizer_module'])
-            self.fields['optimizer_method'] = ChoiceField(choices=((x, x) for x in methods))
+            module = kwargs['initial']['optimizer_module']
+        else:
+            module = args[0].get('optimizer_module')
+        methods = optimizer_methods(module)
+        self.fields['optimizer_method'] = ChoiceField(choices=((x, x) for x in methods))
 
     def clean_circuit(self):
         circuit = self.clean().get('circuit')

--- a/WebCLI/misc/analyze_options.py
+++ b/WebCLI/misc/analyze_options.py
@@ -6,10 +6,16 @@ METHODS = {
            'rmsprop', 'rmsprop-nesterov']
 }
 
+BASIS_SET_CHOICES = ['sto-3g']
 
-def get_methods(module: str):
+
+def optimizer_methods(module: str):
     return METHODS[module]
 
 
-def get_modules():
+def optimizer_modules():
     return list(METHODS.keys())
+
+
+def basis_set_options():
+    return BASIS_SET_CHOICES

--- a/WebCLI/views/new_algorithm.py
+++ b/WebCLI/views/new_algorithm.py
@@ -4,13 +4,13 @@ from django.utils import timezone
 from ..models import Algorithm, Algorithm_version
 from ..forms import AlgorithmForm
 from ..forms import AlgorithmVersionForm
-from ..misc.optimizer_methods import get_modules
+from ..misc.analyze_options import optimizer_modules
 
 
 @login_required
 def new_algorithm(request):
     aform = AlgorithmForm(initial={'user': request.user})
-    vform = AlgorithmVersionForm(initial={'optimizer_module': get_modules()[0]})
+    vform = AlgorithmVersionForm(initial={'optimizer_module': optimizer_modules()[0]})
     if request.method == "POST":
         algorithm_form = AlgorithmForm(request.POST)
         new_algorithm = algorithm_form.save(commit=False)

--- a/WebCLI/views/new_version.py
+++ b/WebCLI/views/new_version.py
@@ -3,7 +3,7 @@ from django.core.exceptions import PermissionDenied
 from django.utils import timezone
 from ..models import Algorithm, Algorithm_version
 from ..forms import AlgorithmVersionForm
-from ..misc.optimizer_methods import get_methods, get_modules
+from ..misc.analyze_options import optimizer_methods, optimizer_modules
 
 
 def add_version(request):
@@ -34,6 +34,7 @@ def add_version(request):
 
 def load_methods(request):
     module = request.GET.get('module')
-    if module in get_modules():
-        return render(request, 'WebCLI/methods_of_module.html', {'methods': get_methods(module)})
+    if module in optimizer_modules():
+        return render(request, 'WebCLI/methods_of_module.html',
+                      {'methods': optimizer_methods(module)})
     return render(request, 'WebCLI/methods_of_module.html', {'methods': []})


### PR DESCRIPTION
## Summary
Issue #97. Solution is to have a list of possible basis sets, and drop down menu according to that. New basis set options are easy to add later. misc/optimizer_methods.py renamed and updated to hold that information.

There is also small fix for situation, where optimizer method drop down menu did not appear after unsuccessful POST (for example syntax error in circuit).

## How to test
Check that only one option is possible for basis set (sto-3g) and that is saved to database. Check that dropdown menus in new algorithm and new version works ok.