### PR TITLE
removed regex clean & model requirement for aOrbitals

### DIFF
--- a/BenchMark/benchmark.py
+++ b/BenchMark/benchmark.py
@@ -11,10 +11,13 @@ app = Celery('benchmark', broker=os.getenv("BROKER_URL", 'pyamqp://guest@localho
 def benchmark_task(metrics_id, molecule, circuit, optimizer_module, optimizer_method):
     if not molecule["transformation"]:
         molecule["transformation"] = None
+    if not molecule["active_orbitals"]:
+        molecule["active_orbitals"] = None
+    else:
+        molecule["active_orbitals"] = molecule["active_orbitals"].replace("\r", "")
 
     # workaround for a Libmark bug
     molecule["structure"] = molecule["structure"].replace("\r", "")
-    molecule["active_orbitals"] = molecule["active_orbitals"].replace("\r", "")
 
     result = run_benchmark(molecule, circuit, optimizer_module, optimizer_method)
     print(result)

--- a/WebCLI/forms.py
+++ b/WebCLI/forms.py
@@ -83,6 +83,14 @@ class MoleculeForm(ModelForm):
             self.add_error('structure', 'Atom syntax (one atom per line): Li 0.0 0.0 1.6')
         return structure
 
+    def clean_active_orbitals(self):
+        active_orbitals = self.clean().get('active_orbitals')
+        if (active_orbitals == ''):
+            return active_orbitals
+        if not qm.molecule.validate_orbitals_syntax(active_orbitals):
+            self.add_error('active_orbitals', 'Orbital syntax (one orbital per line): A1 1 2 4 5 7')
+        return active_orbitals
+
     class Meta:
         model = Molecule
         fields = ['name', 'structure', 'active_orbitals', 'basis_set', 'transformation']

--- a/WebCLI/forms.py
+++ b/WebCLI/forms.py
@@ -83,12 +83,6 @@ class MoleculeForm(ModelForm):
             self.add_error('structure', 'Atom syntax (one atom per line): Li 0.0 0.0 1.6')
         return structure
 
-    def clean_active_orbitals(self):
-        active_orbitals = self.clean().get('active_orbitals')
-        if not qm.molecule.validate_orbitals_syntax(active_orbitals):
-            self.add_error('active_orbitals', 'Orbital syntax (one orbital per line): A1 1 2 4 5 7')
-        return active_orbitals
-
     class Meta:
         model = Molecule
         fields = ['name', 'structure', 'active_orbitals', 'basis_set', 'transformation']

--- a/WebCLI/models.py
+++ b/WebCLI/models.py
@@ -13,7 +13,7 @@ class Algorithm_type(models.Model):
 class Molecule(models.Model):
     name = models.TextField()
     structure = models.TextField()
-    active_orbitals = models.TextField(default="")
+    active_orbitals = models.TextField(blank=True, default="")
     basis_set = models.TextField(default="")
     transformation = models.TextField(blank=True, default="")
 

--- a/WebCLI/tests/testNewMolecule.py
+++ b/WebCLI/tests/testNewMolecule.py
@@ -39,6 +39,16 @@ class TestNewMolecule(TestCase):
         result = len(Molecule.objects.filter(name='Lithium hydride2'))
         self.assertEqual(result, 0)
 
+    def test_add_molecule_with_incorrect_orbitals(self):
+        self.client.post('/newMolecule/',
+                         {'name': 'Lithium hydride3',
+                          'structure': 'H 0.0 0.0 0.0\nLi 0.0 0.0 1.6',
+                          'active_orbitals': '1 2 4 5 7',
+                          'basis_set': 'sto-3g',
+                          'transformation': 'Bravyi-Kitaev'})
+        result = len(Molecule.objects.filter(name='Lithium hydride3'))
+        self.assertEqual(result, 0)
+
     def test_add_molecule_with_no_orbitals(self):
         self.client.post('/newMolecule/',
                          {'name': 'Lithium hydride3',

--- a/WebCLI/tests/testNewMolecule.py
+++ b/WebCLI/tests/testNewMolecule.py
@@ -39,12 +39,11 @@ class TestNewMolecule(TestCase):
         result = len(Molecule.objects.filter(name='Lithium hydride2'))
         self.assertEqual(result, 0)
 
-    def test_add_molecule_with_incorrect_orbitals(self):
+    def test_add_molecule_with_no_orbitals(self):
         self.client.post('/newMolecule/',
                          {'name': 'Lithium hydride3',
                           'structure': 'H 0.0 0.0 0.0\nLi 0.0 0.0 1.6',
-                          'active_orbitals': '1 2 4 5 7',
                           'basis_set': 'sto-3g',
                           'transformation': 'Bravyi-Kitaev'})
         result = len(Molecule.objects.filter(name='Lithium hydride3'))
-        self.assertEqual(result, 0)
+        self.assertEqual(result, 1)


### PR DESCRIPTION
## Summary
Closes #143 . User should now be able to input molecules without active orbitals and run benchmarks with the algorithms using those molecules.
## How to test
Check if adding a molecule without active orbitals succeeds and you get some results from running an algorithm with that specific molecule.