### PR TITLE
http to https in algorithm details view

### DIFF
--- a/templates/WebCLI/algorithm.html
+++ b/templates/WebCLI/algorithm.html
@@ -284,7 +284,7 @@
     {{ accuracy_history_graph_data|json_script:"accuracy-history-graph-data" }}
 
     <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
-    <script src="http://code.jquery.com/jquery-latest.min.js"></script>
+    <script src="https://code.jquery.com/jquery-latest.min.js"></script>
     <script type="text/javascript">
 
         google.charts.load('current', { packages: ['corechart', 'line'] });


### PR DESCRIPTION
## Summary

After merging branch 'info_on_analysis_in_progress' staging server reported and error in algorith details view: Mixed Content: The page at 'https://ohtup-staging.cs.helsinki.fi/quantmark/algorithm/2?version_id=7&metrics_id=7' was loaded over HTTPS, but requested an insecure script 'http://code.jquery.com/jquery-latest.min.js'. This request has been blocked; the content must be served over HTTPS.

## How to test

Check that algorithm details view shows list of running analysis and there is now errors in console.